### PR TITLE
upgrade aes to use autoPadding and for legacy methods to skip the stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": "*"
   },
   "dependencies": {
-    "browserify-aes": "0.6.1",
+    "browserify-aes": "0.7.2",
     "create-ecdh": "1.0.0",
     "diffie-hellman": "2.2.0",
     "browserify-sign": "2.7.0",


### PR DESCRIPTION
adds autopadding options to ECB and CBC ciphers and implements update and final more in line with how node does it 

currently `cipher.on('data', function (d){console.log(d)}).update('foo')` triggers the event here but not in node, this is fixed also errors due to padding and authentication now will only throw if you use them with .final() not with .end() (with .end they will cause an error event)