### PR TITLE
add aliases for hash, hmac, verify, sign, cipher[iv], decipher[iv]

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ function error () {
     ].join('\n'))
 }
 
-exports.createHash = require('./create-hash')
+exports.createHash = exports.Hash = require('./create-hash')
 
-exports.createHmac = require('./create-hmac')
+exports.createHmac = exports.Hmac = require('./create-hmac')
 
 exports.randomBytes = function(size, callback) {
   if (callback && callback.call) {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "node": "*"
   },
   "dependencies": {
-    "browserify-aes": "0.8.0",
+    "browserify-aes": "0.8.1",
     "create-ecdh": "1.0.1",
     "diffie-hellman": "2.2.2",
-    "browserify-sign": "2.7.1",
+    "browserify-sign": "2.7.2",
     "pbkdf2-compat": "2.0.1",
     "public-encrypt": "1.1.0",
     "ripemd160": "0.2.0",


### PR DESCRIPTION
node has crypto.Hash as an alias for crypto.createHash and the same with Hmac, Verify, Sign, Cipher, Cipheriv, Decipher, and Decipheriv