### PR TITLE
upgrade browserify-sign to use determanistic k

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "browserify-aes": "0.8.1",
     "create-ecdh": "1.0.3",
     "diffie-hellman": "2.2.3",
-    "browserify-sign": "2.7.5",
+    "browserify-sign": "2.8.0",
     "pbkdf2-compat": "2.0.1",
     "public-encrypt": "1.1.2",
     "ripemd160": "0.2.0",


### PR DESCRIPTION
This updates browserify-sign to generate deterministic k values for DSA signatures based on [rfc 6979](http://tools.ietf.org/html/rfc6979).  

The reason for this is that in DSA if the k value is ever repeated for the same key with a different input (even partially) this can lead to an attacker being able to figure out the key used to sign a message.  Previously a random value was used for k (in line with what openssl does), but the problem here is that it puts a huge amount of trust in the browsers random number generator, what rfc6979 defines is a method of using hmac of the private key and message digest to calculate an unpredictable k value that varies with different messages and the same key.  

this passes all the non-eliptical curve test vectors in the rfc (including implementing DSA with sha2 in order to test against those)